### PR TITLE
ArchivesSpace migration fixes

### DIFF
--- a/packages/core/templates/default/collection-list.inc.php
+++ b/packages/core/templates/default/collection-list.inc.php
@@ -251,7 +251,7 @@ function MakeNormal($item,$key){
 	unset($item->PublicationDateDay);
 	unset($item->PublicationDateYear);
 	unset($item->Content);
-	unset($item->Languages);
+	//unset($item->Languages);
 	unset($item->Books);
 	unset($item->Repository);
 	unset($item->Classification);


### PR DESCRIPTION
- Allow language of materials information for the collection records to be included in the JSON used by the ArchivesSpace migration tool